### PR TITLE
[READY] Env deletion also removes capture and heightmap images

### DIFF
--- a/php/deleteEnv.php
+++ b/php/deleteEnv.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 
 require('db.php');
 
@@ -7,3 +8,6 @@ $envDeleteId = $_POST['envDeleteId'];
 $sth = $dbh->prepare("DELETE FROM environments WHERE envId=:envDeleteId");
 $sth->bindParam(':envDeleteId', $envDeleteId);
 $result = $sth->execute();
+
+unlink("../img/user/{$_SESSION['userId']}/capture-$envDeleteId.jpg");
+unlink("../img/user/{$_SESSION['userId']}/height-map-$envDeleteId.png");


### PR DESCRIPTION
The original env-delete work was only removing the database entry; I forgot about the capture and heightmap images.
