### PR TITLE
[READY] Homepage #primary-header height

### DIFF
--- a/sass/_page-home.scss
+++ b/sass/_page-home.scss
@@ -1,5 +1,5 @@
 #primary-header {
-    height: 2000px;
+    height: 1100px;
     position: fixed;
     left: 0;
     right: 0;
@@ -93,7 +93,7 @@
 }
 
 #secondary-header {
-    margin-top: 2000px;
+    margin-top: 1100px;
     position: relative;
     display: block;
     text-align: center;


### PR DESCRIPTION
I've reduced the height of the #primary-header from `2000px` to `1100px` before the javascript kicks in.

This reduces the jump and also means that non-js / slow loading users don't have to scroll so far.
