### PR TITLE
[READY] Wrong username on user nav

### DIFF
--- a/model-user.php
+++ b/model-user.php
@@ -1,7 +1,7 @@
 <?php
 
-$userVars = explode('/', $q);
-$username = $userVars[1];
+$userVars     = explode('/', $q);
+$userUsername = $userVars[1];
 
 if(isset($_GET['page'])) {
     $page = $_GET['page'];
@@ -10,11 +10,11 @@ if(isset($_GET['page'])) {
 }
 
 require_once('php/User.php');
-$user = User::getData($username);
+$user = User::getData($userUsername);
 
 if($user) {
-    $environments      = User::getEnvironments($username, $page);
-    $totalEnvironments = User::getTotalEnvironments($username);
+    $environments      = User::getEnvironments($userUsername, $page);
+    $totalEnvironments = User::getTotalEnvironments($userUsername);
     $file = 'user-profile';
 } else {
     $file = '404';


### PR DESCRIPTION
Turns out this wasn't actually much of a security issue as we thought.

When visiting another user's profile, it wasn't actually logging in as that user, it was just displaying the wrong username in the `#user-message` and the wrong links in the user nav. The user wouldn't have been able to do anything like delete another user's environments for instance.

The problem only occurred on the live server and not on the sandbox, probably due to differing PHP versions.

For some reason, on live, session variables can be accessed in two ways:

Let's say we set a session variable called 'username':
`$_SESSION['username'] = 'james';`

That variable can be accessed like so:
`echo $_SESSION['username'];`
OR
`echo $username;`

Both of which would echo out 'james'.

Therefore, because I was using the `$username` variable for something else, it was being overridden.

I also can't find anywhere in the PHP documentation saying that PHP session variables can be accessed this way - strange.
